### PR TITLE
fixes "warning: `<<' after local variable or literal is interpreted a…

### DIFF
--- a/lib/fxmlloader/elts.rb
+++ b/lib/fxmlloader/elts.rb
@@ -155,7 +155,7 @@ class Element
         if (@loadListener != nil)
           @loadListener.readEventHandlerAttribute(localName, value);
         end
-        eventHandlerAttributes <<(Attribute.new(localName, nil, value));
+        eventHandlerAttributes << (Attribute.new(localName, nil, value));
       else
         i = localName.rindex('.');
 


### PR DESCRIPTION
…s binary operator"
I'm not sure if this fixes anything functional but at least it removes the warning.