### PR TITLE
Use #add over <<

### DIFF
--- a/lib/fxmlloader/elts.rb
+++ b/lib/fxmlloader/elts.rb
@@ -155,7 +155,7 @@ class Element
         if (@loadListener != nil)
           @loadListener.readEventHandlerAttribute(localName, value);
         end
-        eventHandlerAttributes << (Attribute.new(localName, nil, value));
+        eventHandlerAttributes.add(Attribute.new(localName, nil, value));
       else
         i = localName.rindex('.');
 
@@ -539,7 +539,7 @@ class ScriptEventHandler
   def handle(event)
     # Don't pollute the page namespace with values defined in the script
     engineBindings = @scriptEngine.getBindings(ScriptContext::ENGINE_SCOPE);
-    #localBindings = @scriptEngine.createBindings(); # TODO: this causes errors with nashorn in jdk8 by creating a different kind of 
+    #localBindings = @scriptEngine.createBindings(); # TODO: this causes errors with nashorn in jdk8 by creating a different kind of
     # script object that doesn't respect the magic nashorn.global object
     localBindings = Java::JavaxScript::SimpleBindings.new
     localBindings.put_all(engineBindings)


### PR DESCRIPTION
#### Changes

```
<..>/gems/jruby-9.2.10.0/gems/jrubyfx-fxmlloader-0.4.1-java/lib/fxmlloader/elts.rb:158: warning: `<<' after local variable or literal is interpreted as binary operator
<..>/gems/jruby-9.2.10.0/gems/jrubyfx-fxmlloader-0.4.1-java/lib/fxmlloader/elts.rb:158: warning: even though it seems like here document
```

Running JRubyFX complains with the above when `<<` is used. This opts for using `#add` to do away with the noise.