### PR TITLE
Patch to allow the JRubyFX-FXMLLoader work with OpenJFX Pre-Built binary

### DIFF
--- a/lib/fxmlloader/value_elts.rb
+++ b/lib/fxmlloader/value_elts.rb
@@ -1,6 +1,11 @@
 require_relative './elts'
 
-class StupidFixTODOInsets < Java::javafx::geometry::InsetsBuilder
+# By Chris on 15th May 2020
+# Support OpenJFX, requires JRuby version that supports OpenJFX
+# OpenJFX no longer includes javafx.geometry.InsetsBuilder
+# Tested on OpenJFX version 11.0.2, 14.01 & 15 ea on 15th May 2020
+#class StupidFixTODOInsets < Java::javafx::geometry::InsetsBuilder
+class StupidFixTODOInsets #< Java::javafx::geometry::InsetsBuilder
   def initialize()
     super
   end

--- a/lib/fxmlloader/value_elts.rb
+++ b/lib/fxmlloader/value_elts.rb
@@ -4,8 +4,7 @@ require_relative './elts'
 # Support OpenJFX, requires JRuby version that supports OpenJFX
 # OpenJFX no longer includes javafx.geometry.InsetsBuilder
 # Tested on OpenJFX version 11.0.2, 14.01 & 15 ea on 15th May 2020
-#class StupidFixTODOInsets < Java::javafx::geometry::InsetsBuilder
-class StupidFixTODOInsets #< Java::javafx::geometry::InsetsBuilder
+class StupidFixTODOInsets 
   def initialize()
     super
   end


### PR DESCRIPTION
This works hand in hand with the pull request [JRubyFX Support Pre-Built OpenJFX Libraries](https://github.com/jruby/jrubyfx/pull/127) as one of the class javafx.geometry.InsetsBuilder no longer available from the OpenJFX package.